### PR TITLE
Workaround for skimmed HiForestTrees where the HLTTree is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,13 @@ It uses directly as inputs the HiForest contents.
 The executable can be compiled with `scram b`.
 To run on a single file for testing one  can give the command
 ```
-make2Ltree --in /eos/cms/store/cmst3/group/hintt/HIN-19-001-v2/TTJets_TuneCP5_HydjetDrumMB_5p02TeV-amcatnloFXFX-pythia8/Chunk_0_ext0.root --out test.root         --mc --max 1000
+make2Ltree --in /eos/cms/store/cmst3/group/hintt/HIN-19-001-09Aug/TTJets_TuneCP5_HydjetDrumMB_5p02TeV-amcatnloFXFX-pythia8/Chunk_0_ext0.root --out test.root --mc --amcatnlo --max 1000
+make2Ltree --in /eos/cms/store/cmst3/group/hintt/HIN-19-001-09Aug/WJetsToLNu_TuneCP5_HydjetDrumMB_5p02TeV-amcatnloFXFX-pythia8_Muons/Chunk_0_ext0.root --out test_wmu.root --mc --amcatnlo --max 5000
 make2Ltree --in /eos/cms/store/cmst3/group/hintt/PbPb2018/TT_TuneCP5_5p02TeV-powheg-pythia8/Chunk_0_ext0.root               --out test_pp.root --pp --mc --max 1000
 ```
 or to run on a data file:
 ```
-make2Ltree --in /eos/cms/store/cmst3/group/hintt/HIN-19-001-v2/SkimMuons_04Apr2019-v1/Chunk_0_ext0.root --out test.root --max 1000
+make2Ltree --in /eos/cms/store/cmst3/group/hintt/HIN-19-001-09Aug/SkimMuons_04Apr2019-v1/Chunk_0_ext0.root --out test.root --max 1000
 ```
 
 To loop over all the available forest trees better to use condor and then merge the outputs.

--- a/scripts/runanalysis.py
+++ b/scripts/runanalysis.py
@@ -12,16 +12,19 @@ def launch(indir,out,allowTags=[]):
             if "Drum" in tag:
                 if "amcatnlo" in tag:
                     extraOpts += " --amcatnlo "
+                    if '_Muons' in tag or '_Electrons' in tag:
+                        extraOpts += " --skim"
             else:
                 extraOpts=" --pp "
         os.system('python scripts/launchAnalysis.py {indir}/{tag} {out} {tag} {extraOpts}'.format(indir=indir, tag=tag, out=out, extraOpts=extraOpts))
 
-out='/eos/cms/store/cmst3/group/hintt/PbPb2018_skim19June/'
+out='/eos/cms/store/cmst3/group/hintt/PbPb2018_skim13August/'
+indir='/eos/cms/store/cmst3/group/hintt/HIN-19-001-09Aug'
 
-indir='/eos/cms/store/cmst3/group/hintt/HIN-19-001-v2/'
-launch(indir,out)
-
-indir='/eos/cms/store/cmst3/group/hintt/PbPb2018_rereco/'
-allowTags=['SkimElectrons_04Apr2019-v1', 
-           'SkimMuons_04Apr2019-v1']
+allowTags=['WJetsToLNu_TuneCP5_HydjetDrumMB_5p02TeV-amcatnloFXFX-pythia8_Electrons',
+           'WJetsToLNu_TuneCP5_HydjetDrumMB_5p02TeV-amcatnloFXFX-pythia8_Muons']
 launch(indir,out,allowTags)
+
+#allowTags=['SkimElectrons_04Apr2019-v1', 
+#           'SkimMuons_04Apr2019-v1']
+#launch(indir,out,allowTags)


### PR DESCRIPTION
Trigger matched leptons are always required
In skim mode assume HLT bits from trigger matched leptons...
